### PR TITLE
Redirect to created post after creation

### DIFF
--- a/src/views/pageScripts/invite.js
+++ b/src/views/pageScripts/invite.js
@@ -25,7 +25,7 @@ if (inviteBtn) {
     api.Post('invites', JSON.stringify({ title: jobTitle.value, body: jobDetails.value, media: `https://loremflickr.com/320/240/${jobTitle.value.slice(0, 3)}` }), true)
       .then(res => {
         // navigate to somewhere. created post maybe
-        window.location.href = '/jobInvites';
+        window.location.href = `/post/${res.data.inviteId}`;
         togglePreloader('none');
       })
       .catch(err => {


### PR DESCRIPTION
After post creation, it should go to the created post, not the job invites page. 