### PR TITLE
Protect edit page route and fix login/logout bug

### DIFF
--- a/src/controllers/inviteController.js
+++ b/src/controllers/inviteController.js
@@ -177,6 +177,7 @@ export const renderSinglePostPage = async (req, res) => {
     invite: data[1],
     isAuth: req.isAuth,
     isAdmin: req.auth.isAdmin,
+    userId: req.auth.userId,
   });
 };
 
@@ -216,8 +217,17 @@ export const renderAdminJobInvitesPage = async (req, res) => {
  * @param {object} res
  * @returns {object} json response
  */
-export const renderEditInvitePage = async (req, res) => res.render('editPost', {
-  invite: req.invite,
-  isAuth: req.isAuth,
-  isAdmin: req.auth.isAdmin,
-});
+export const renderEditInvitePage = async (req, res) => {
+  if (req.invite.userId !== req.auth.userId && !req.auth.isAdmin) {
+    return res.render('401', {
+      isAuth: req.isAuth,
+      isAdmin: req.auth.isAdmin,
+    });
+  }
+
+  return res.render('editPost', {
+    invite: req.invite,
+    isAuth: req.isAuth,
+    isAdmin: req.auth.isAdmin,
+  })
+};

--- a/src/views/401.ejs
+++ b/src/views/401.ejs
@@ -1,0 +1,15 @@
+<% include partials/header %>
+<% include partials/nav %>
+
+    <div class="container">
+        <div class="text-center">
+            <div class="card-body">
+                <h2 class="p-4 default-text">401</h2>
+                <span class="text-dark text-center">You are not authorized to perform this action</span><br><br>
+                <span class="text-dark text-center"> <a class="go_back" href="/">GO BACK HOME</a></span>
+
+            </div>
+            
+    </div>
+    </div>
+<% include partials/footer %>

--- a/src/views/pageScripts/login.js
+++ b/src/views/pageScripts/login.js
@@ -31,7 +31,7 @@ if (document.querySelector('#login-btn')) {
         localStorage.setItem('token', res.data.token);
         localStorage.setItem('user', JSON.stringify(res.data)); // convert from [object object]
 
-        document.cookie = `login=${res.data.token}`;
+        document.cookie = `login=${res.data.token};path=/`; // path required so cookie always sends.
         window.location.href = '/jobInvites';
       })
       .catch(err => {
@@ -52,7 +52,7 @@ if (document.querySelector('#logout')) {
     ev.preventDefault();
 
     localStorage.removeItem('token');
-    document.cookie = "signOut=true";
+    document.cookie = "signOut=true;path=/"; // Path required so cookie always sends
 
     window.location.href = '/';
   });

--- a/src/views/singlepost.ejs
+++ b/src/views/singlepost.ejs
@@ -9,6 +9,7 @@
           <div class="container mt-4" class="post-meta" id="<%=invite.inviteId%>">
             <span class="d-flex flex-row-reverse justify-content-between">
           <span class="dropdown">
+            <% if ((invite.userId === userId) || isAdmin ) { %>
             <i class=" fas fa-ellipsis-h  dropdown-toggle" id="dropdownMenuButton" data-toggle="dropdown"
               aria-haspopup="true" aria-expanded="false">
             </i>
@@ -17,6 +18,7 @@
               <!-- <a class="dropdown-item" href="#">Report</a> -->
               <a class="dropdown-item" href="#">Delete Post </a>
             </span>
+            <% } %>
             </span>
 
             <span>


### PR DESCRIPTION
This adds a 401 page (in case an unauthorised user tries to edit a post). 

There was a bug with login/logout where the cookies wouldn't be sent the server so the user would the navbar would be in the wrong state. It was fixed by adding a path to the cookie string. 

401 page:
![2019-10-30_22-14](https://user-images.githubusercontent.com/14963262/67899507-b6938a00-fb62-11e9-98b1-f58e7c9d809d.png)
