### PR TITLE
Remove double message in search results page

### DIFF
--- a/src/views/searchResults.ejs
+++ b/src/views/searchResults.ejs
@@ -40,17 +40,19 @@
     <section class="job-invites">
       <% if (invites.length === 0) { %>
       <!-- No invites -->
-      <div class="card card-secondary text-center container my-4">
+      <div class="card card-secondary text-center container my-4 p-3 bg-light">
         No matching invites were found 😢
         <p>Submit your invite <a href="/post">here</a>, to get feedback from the community.</p>
       </div>
       <% } %>
 
+      <% if (invites.length > 0) { %>
       <!-- Users choice wasn't in the list -->
-      <div class="card card-secondary text-center container p-2 bg-light my-4">
+      <div class="card card-secondary text-center container my-4 p-3 bg-light">
         Didn't find what you were looking for?
         <p>Submit your invite <a href="/post">here</a>, to get feedback from the community.</p>
       </div>
+      <% } %>
 
       <% if (invites.length > 0) { %>
       <% for (invite of invites) { %>


### PR DESCRIPTION
*Problem:* Two notification messages were showing in empty search results page
![image](https://user-images.githubusercontent.com/34924520/68228717-38b5ff80-fff6-11e9-914b-0d55427d9e11.png)

*Fix:* Add condition to render one
![image](https://user-images.githubusercontent.com/34924520/68228767-4cf9fc80-fff6-11e9-9bab-372d2a5ff4c6.png)
