### PR TITLE
Fix notification bug

### DIFF
--- a/src/views/pageScripts/notification.js
+++ b/src/views/pageScripts/notification.js
@@ -51,7 +51,12 @@ const renderNotifications = (notifications) => {
   const notificationHTML = (notifications.length > 0) ? notifications.map(getNotificationHTML)
     : ['You have no notifications'];
   notificationContainer.innerHTML = notificationHTML.join('');
-  notificationBadge.innerHTML = notifications.filter(n => !n.isSeen).length;
+  const notificationCount = notifications.filter(n => !n.isSeen).length;
+  notificationBadge.innerHTML = notificationCount;
+  if (notificationCount === 0) {
+    return notificationBadge.classList.add('toggle-badge');
+  }
+  notificationBadge.classList.remove('toggle-badge');
 };
 
 if (notificationContainer && notificationBadge) {
@@ -94,11 +99,12 @@ const markNotificationsAsRead = () => {
           const elem = document.querySelector(`[data-notification="${n.notificationId}"]`);
           elem.outerHTML = getNotificationHTML(n);
         }
-      })
-      .catch(console.error);
+        if (Number(notificationBadge.innerHTML) === 0) {
+          notificationBadge.classList.add('toggle-badge');
+        }
+      }).catch(console.error);
   }
 };
-
 // eslint-disable-next-line max-len
 if (notificationContainer) { // mark `visible` notifications as seen when notification dropdown is scrolled
   notificationContainer.addEventListener('scroll', e => {
@@ -106,8 +112,10 @@ if (notificationContainer) { // mark `visible` notifications as seen when notifi
   });
 }
 
+
 if (bell) { // mark `visible` notifications as seen when notification dropdown is clicked
   bell.addEventListener('click', () => {
+    console.log('b4 notificationBadge.innerHTML :', notificationBadge.innerHTML);
     setTimeout(() => markNotificationsAsRead(), 500);
   });
 }
@@ -119,6 +127,10 @@ socket.on('new:notification', notification => {
     notificationBadge.innerHTML = Number(notificationBadge.innerHTML) + 1;
     notificationContainer.innerHTML = getNotificationHTML(notification)
     + notificationContainer.innerHTML;
+
+    if (Number(notificationBadge.innerHTML) !== 0) {
+      notificationBadge.classList.remove('toggle-badge');
+    }
 
     // show on-screen notification
     showSnackBar(notification.message);

--- a/src/views/partials/nav2.ejs
+++ b/src/views/partials/nav2.ejs
@@ -117,7 +117,7 @@
         bottom: 23px;
         left: 20px
     }
-    
+   
     .notification-menu {
         overflow-y: auto;
         overflow-x: hidden;
@@ -184,9 +184,13 @@
     }
     
     .badge {
-        background-color: #ffd740;
+        background-color: #4a3f11;
         color: #fff;
     }
+    .toggle-badge {
+        display: none;
+    }
+
     /* Snackbar */
     
     #snackbar {
@@ -296,7 +300,7 @@
                 <li class="nav-item dropdown notification-bar">
 
                     <a class="nav-link dropdown-toggle" style="padding-top: 3px;" href="javascript:void(0)"><i 
-             class="far fa-bell fa-2x notification-icon" onclick="notificationToggle()" id="bell-icon"></i><span class="badge"></span></a>
+            class="far fa-bell fa-2x notification-icon" onclick="notificationToggle()" id="bell-icon"></i><span class="badge toggle-badge"></span></a>
                     <div id="branded" class="notification-menu hide shadow">
                         <!-- notification goes here -->
                     </div>


### PR DESCRIPTION
### Task

Changed the background color of the unread count badge so that the number can be more visible. 

When there is no notification, rather than show 0, I remove the unread count badge altogether. That means the count should only show when there are new notifications.

