### PR TITLE
feat(forgotpassword): add fe pages, script & route

### DIFF
--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -109,7 +109,6 @@ export const initRoutes = app => {
     name: req.auth.name,
     meta: { title: 'Terms - Is This A Real Job', description: genericDescription }
   }));
-  
 
   app.get('/about', (req, res) => res.render('about', {
     isAuth: req.isAuth,
@@ -142,6 +141,23 @@ export const initRoutes = app => {
     meta: { title: 'Admin Home - Is This A Real Job', description: genericDescription }
   }));
 
+  app.get('/terms', (req, res) => res.render('terms'));
+
+  app.get('/forgotpassword', (req, res) => res.render('forgotPassword', {
+    isAuth: req.isAuth,
+    isAdmin: req.auth.isAdmin,
+    username: req.auth.username,
+    name: req.auth.name,
+    meta: { title: 'Forgot Password - Is This A Real Job', description: genericDescription }
+  }));
+
+  app.get('/resetpassword', (req, res) => res.render('resetPassword', {
+    isAuth: req.isAuth,
+    isAdmin: req.auth.isAdmin,
+    username: req.auth.username,
+    name: req.auth.name,
+    meta: { title: 'Reset Password - Is This A Real Job', description: genericDescription }
+  }));
 
   // Edit post endpoint
   app.get(
@@ -167,7 +183,6 @@ export const initRoutes = app => {
   );
 
 
-  app.get('/terms', (req,res)=>res.render('terms'))
   // Twitter Auth
   app.get('/auth/twitter', twitterAuthenticate);
   app.get('/auth/twitter/redirect', twitterAuthCallback);

--- a/src/views/forgotPassword.ejs
+++ b/src/views/forgotPassword.ejs
@@ -1,0 +1,44 @@
+<% include partials/header %>
+<% include partials/nav %>
+
+<style>
+  h4 {
+    font-size: 22px;
+    line-height: 26px;
+  }
+
+  .content p {
+    text-align: justify;
+  }
+
+  p {
+    font-size: 16px;
+    line-height: 28px;
+  }
+
+</style>
+
+<div id="cover">
+  <div class="loader"></div>
+</div>
+<div class="container-fluid text-left p-3 content">
+  <div class="col-6 offset-3">
+    <h4 class="font-weight-bold text-center">Forgot Password?</h4>
+
+    <p class="text-center">
+      Don't panic! We can help. Just enter the email address you signed up with in the space below and we will email you
+      a password reset link.
+    </p>
+
+    <div class="input-group mt-5">
+      <input type="text" class="form-control" placeholder="someone@example.com" aria-label="Email Address" id="emailField">
+      <div class="input-group-append">
+        <button class="btn btn-primary" id="forgotPasswordBtn" type="button">Submit</button>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+
+<% include partials/footer %>

--- a/src/views/pageScripts/forgotPassword.js
+++ b/src/views/pageScripts/forgotPassword.js
@@ -1,0 +1,66 @@
+/* eslint-disable no-undef */
+console.log('forgot password loaded', api); // Itarj Api has already been declared
+
+/* Forgot Password Logic */
+const forgotPasswordBtn = document.querySelector('#forgotPasswordBtn');
+const emailField = document.querySelector('#emailField');
+
+if (forgotPasswordBtn) {
+  forgotPasswordBtn.addEventListener('click', e => {
+    // consume forgot password api; change properties as required
+    const data = {
+      email: emailField.value
+    };
+
+    api
+      .Post('users/forgotpassword', JSON.stringify(data))
+      .then(console.log)
+      .catch(console.error);
+  });
+}
+
+/* Reset Password Logic */
+const changePasswordBtn = document.querySelector('#changePasswordBtn');
+const newPasswordField = document.querySelector('#newPasswordField');
+const confirmPasswordField = document.querySelector('#confirmPasswordField');
+
+/**
+ * Helper fn to show error message on template
+ * @param {string} [message] the message to show on the template
+ * @param {boolean} [hideError] specifies if the error should be hidden
+ *  */
+const showError = (message = '', hideError = true) => {
+  const elem = document.querySelector('#rp-error');
+  elem.innerHTML = message;
+  elem.style.display = hideError ? 'none' : 'block';
+};
+
+if (confirmPasswordField) {
+  // todo: may add more fe validation for password
+  confirmPasswordField.addEventListener('keyup', () => {
+    if (newPasswordField.value !== confirmPasswordField.value) {
+      // passwords don't match error
+      showError('Passwords do not match', false);
+    } else {
+      showError();
+    }
+  });
+}
+
+if (changePasswordBtn) {
+  changePasswordBtn.addEventListener('click', e => {
+    if (newPasswordField.value.length < 6) {
+      showError('Password must be at least 6 characters.', false);
+      return;
+    }
+    // consume reset password api; change properties as required
+    const data = {
+      password: newPasswordField.value
+    };
+
+    api
+      .Post('users/resetpassword', JSON.stringify(data))
+      .then(console.log)
+      .catch(console.error);
+  });
+}

--- a/src/views/partials/footer.ejs
+++ b/src/views/partials/footer.ejs
@@ -148,6 +148,7 @@
 <script type="text/javascript" src="/metrics.js"></script>
 <script src="https://requirejs.org/docs/release/2.3.5/minified/require.js"></script>
 <script type="text/javascript" src="/analysis.js"></script>
+<script type="text/javascript" src="/forgotPassword.js"></script>
 </body>
 
 </html>

--- a/src/views/resetPassword.ejs
+++ b/src/views/resetPassword.ejs
@@ -1,0 +1,53 @@
+<% include partials/header %>
+<% include partials/nav %>
+
+<style>
+  h4 {
+    font-size: 22px;
+    line-height: 26px;
+  }
+
+  .content p {
+    text-align: justify;
+  }
+
+  p {
+    font-size: 16px;
+    line-height: 28px;
+  }
+
+  #rp-error {
+    display: none;
+    font-size: small;
+  }
+
+</style>
+
+<div id="cover">
+  <div class="loader"></div>
+</div>
+<div class="container-fluid text-left p-3 content">
+  <div class="col-6 offset-3">
+    <h4 class="font-weight-bold text-center">Reset Password</h4>
+
+    <p class="text-center">
+      You're just one step away from a brand new <em>unique</em> password!
+    </p>
+
+    <p class="text-center text-danger" id="rp-error"></p>
+
+    <form class="mt-5 text-center">
+      <div class="form-group">
+        <input type="text" class="form-control" id="newPasswordField" placeholder="New Password">
+      </div>
+      <div class="form-group">
+        <input type="text" class="form-control" id="confirmPasswordField" placeholder="Confirm New Password">
+      </div>
+      <button type="button" id="changePasswordBtn" class="btn btn-primary mb-2">Change Password</button>
+    </form>
+  </div>
+
+</div>
+
+
+<% include partials/footer %>


### PR DESCRIPTION
### What's in this PR?

- Add frontend pages for forgot password and reset password
- Add page script for consuming FP and RP endpoints as well as rendering errors on the frontend
- Add route to navigate to created pages stated above
- Refactor: moved the `terms` route to the FE routes group