### PR TITLE
[#169573790] Hide notification dropdown when account menu is displayed.

### DIFF
--- a/public/css/notification.css
+++ b/public/css/notification.css
@@ -1,7 +1,7 @@
   /* notificaion */
   
   .notification {
-    font-size: 0.7em;
+    font-size: 1em;
     padding: 10px;
     background-color: #fa8880ee;
     color: #fff;

--- a/src/controllers/notificationController.js
+++ b/src/controllers/notificationController.js
@@ -42,10 +42,9 @@ import {
  * @returns {object} json response
  */
 export const getNotifications = async (req, res) => {
-  const notifications = await findNotificationsForUser(req.auth.userId)
-    .catch(error => respondWithWarning(res, error.status, error.message));
-
-  return respondWithSuccess(res, 200, 'Successful', notifications);
+  findNotificationsForUser(req.auth.userId)
+    .then((notifications)=> respondWithSuccess(res, 200, 'Successful', notifications))
+    .catch((error)=> respondWithWarning(res, error.status, error.message));
 };
 
 

--- a/src/views/partials/nav2.ejs
+++ b/src/views/partials/nav2.ejs
@@ -391,6 +391,19 @@
             }
         }
 
+        //Close notifications dropdown when user-account dropdown is clicked.
+        document.querySelector('.user-name-initials')
+          .onclick = (event)=> {
+            let dropdowns = document.getElementsByClassName("notification-menu");
+            let i;
+            for (i = 0; i < dropdowns.length; i++) {
+              let openDropdown = dropdowns[i];
+              if (openDropdown.classList.contains('show')) {
+                openDropdown.classList.remove('show');
+              }
+            }
+          }
+        //
 
         const links = document.getElementsByClassName('notification-wrapper');
 


### PR DESCRIPTION
### Before
If the  notifications dropdown was open, and you clicked on user-name-initials, the account options was hidden under the notifications dropdown.

### Now
The notifications are automatically hidden when the account options are clicked, so this issue no longer appears.

#### Also...
1. Increased font size of error notif text.
2. Fix an issue with using `.catch` together with await in `notificationController.js`. The function doesn't terminate after the catch block, causing a conflict. Switched from await to `.then` to resolve this.